### PR TITLE
Fix stack overflow

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -244,64 +244,57 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         Error::syntax(reason, position.line, position.column)
     }
 
-    /// Returns the first non-comment byte without consuming it, or `None` if
-    /// EOF is encountered.
-    fn parse_comment(&mut self) -> Result<Option<u8>> {
-        // Move the cursor after the first slash.
-        self.eat_char();
-
-        match tri!(self.peek()) {
-            Some(b'/') => self.parse_line_comment(),
-            Some(b'*') => self.parse_block_comment(),
-
-            // Random bad `/` in a whitespace position.
-            // Lie, false rewind.
-            // FIXME: Actually rewind?
-            _ => Ok(Some(b'/')),
-        }
-    }
-
-    fn parse_line_comment(&mut self) -> Result<Option<u8>> {
-        // Eat the second character of the prefix.
-        self.eat_char();
+    /// A "/" character has already been consumed, and the next character is
+    /// also "/". Consume all characters up to but not including end-of-line.
+    fn consume_line_comment(&mut self) -> Result<()> {
         loop {
+            self.eat_char();
             match tri!(self.peek()) {
-                Some(b'\r') | Some(b'\n') => {
-                    self.eat_char();
-                    return self.parse_whitespace();
+                Some(b'\r') | Some(b'\n') | None => {
+                    return Ok(());
                 }
-                Some(_) => self.eat_char(),
-                None => return self.parse_whitespace(),
+                Some(_) => {}
             };
         }
     }
 
-    fn parse_block_comment(&mut self) -> Result<Option<u8>> {
-        // Eat the second character of the prefix.
-        self.eat_char();
-
-        // Try to find the suffix.
+    /// A "/" character has already been consumed, and the next character is
+    /// "*". Consume all characters up to and including the next "*/" sequence
+    /// following the current "*" character.
+    ///
+    /// Currently, if the data stream ends with an un-terminated block comment,
+    /// it ignores the comment instead of returning an error. This is the
+    /// behavior of the original version of serde_jsonc2; it was not changed by
+    /// the PR that fixed the stack overflow problem.
+    fn consume_block_comment(&mut self) -> Result<()> {
         loop {
+            self.eat_char();
             match tri!(self.peek()) {
                 Some(b'*') => {
                     self.eat_char();
                     match tri!(self.peek()) {
                         Some(b'/') => {
                             self.eat_char();
-                            return self.parse_whitespace();
+                            return Ok(());
                         }
-                        Some(_) => self.eat_char(),
-                        None => return self.parse_whitespace(),
+                        Some(_) => {}
+                        None => return Ok(()),
                     }
                 }
-                Some(_) => self.eat_char(),
-                None => return self.parse_whitespace(),
+                Some(_) => {}
+                None => return Ok(()),
             };
         }
     }
 
     /// Returns the first non-whitespace byte without consuming it, or `None` if
     /// EOF is encountered.
+    ///
+    /// If a "/" character is encountered while consuming whitespace, if that
+    /// character is the beginning of a comment then the comment is also
+    /// consumed as if it were whitespace. If the "/" character is not the
+    /// start of a comment (is not followed by another "/" or by "*") then the
+    /// first "/" character is both consumed and returned.
     fn parse_whitespace(&mut self) -> Result<Option<u8>> {
         loop {
             match tri!(self.peek()) {
@@ -310,7 +303,18 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                 }
 
                 Some(b'/') => {
-                    return self.parse_comment();
+                    self.eat_char();
+                    match tri!(self.peek()) {
+                        Some(b'/') => {
+                            self.consume_line_comment()?;
+                        }
+                        Some(b'*') => {
+                            self.consume_block_comment()?;
+                        }
+                        _ => {
+                            return Ok(Some(b'/'));
+                        }
+                    }
                 }
 
                 other => {

--- a/tests/many_consecutive_comments.rs
+++ b/tests/many_consecutive_comments.rs
@@ -17,20 +17,20 @@ const NUM_CONSECUTIVE_COMMENTS: usize = 128;
 
 #[test]
 fn test_many_consecutive_block_comments() {
-    let path = create_jsonc_bytes(|w, i| {
+    let bytes = create_jsonc_bytes(|w, i| {
         // Create block comment
         writeln!(w, "/* Comment line {i} */").unwrap()
     });
-    load_jsonc_bytes_in_thread(path);
+    load_jsonc_bytes_in_thread(bytes);
 }
 
 #[test]
 fn test_many_consecutive_line_comments() {
-    let path = create_jsonc_bytes(|w, i| {
+    let bytes = create_jsonc_bytes(|w, i| {
         // Create line comment
         writeln!(w, "// Comment line {i}").unwrap()
     });
-    load_jsonc_bytes_in_thread(path);
+    load_jsonc_bytes_in_thread(bytes);
 }
 
 fn create_jsonc_bytes<F>(mut create_comment_callback: F) -> Vec<u8>

--- a/tests/many_consecutive_comments.rs
+++ b/tests/many_consecutive_comments.rs
@@ -1,0 +1,70 @@
+//! Test deserializing JSONC with many consecutive comments.
+//! On earlier versions of serde_jsonc2 these tests would not just fail
+//! but get a fatal error due to stack overflow.
+
+use serde_jsonc2::Value;
+use std::{io::Write, thread};
+
+const STACK_SIZE: usize = 2048;
+
+/// Number of consecutive comments to add to the JSONC file.
+/// Without the stack overflow fix, on my machine with a 2k thread stack size,
+/// I can have a maximum of
+/// - 66 consecutive line comments
+/// - 58 consecutive block comments
+/// before I get a stack overflow error.
+const NUM_CONSECUTIVE_COMMENTS: usize = 128;
+
+#[test]
+fn test_many_consecutive_block_comments() {
+    let path = create_jsonc_bytes(|w, i| {
+        // Create block comment
+        writeln!(w, "/* Comment line {i} */").unwrap()
+    });
+    load_jsonc_bytes_in_thread(path);
+}
+
+#[test]
+fn test_many_consecutive_line_comments() {
+    let path = create_jsonc_bytes(|w, i| {
+        // Create line comment
+        writeln!(w, "// Comment line {i}").unwrap()
+    });
+    load_jsonc_bytes_in_thread(path);
+}
+
+fn create_jsonc_bytes<F>(mut create_comment_callback: F) -> Vec<u8>
+where
+    F: FnMut(&mut dyn Write, usize),
+{
+    let mut w = Vec::<u8>::new();
+    for i in 0..NUM_CONSECUTIVE_COMMENTS {
+        create_comment_callback(&mut w, i);
+    }
+    writeln!(w, "{{\"a\": 1}}").unwrap();
+    w.flush().unwrap();
+    w
+}
+
+fn load_jsonc_bytes_in_thread(bytes: Vec<u8>) {
+    let join_handle = thread::Builder::new()
+        .name(String::from("many_consecutive_comments"))
+        .stack_size(STACK_SIZE)
+        .spawn(move || serde_jsonc2::from_reader::<_, Value>(bytes.as_slice()))
+        .unwrap();
+    let thread_result = join_handle.join();
+    match thread_result {
+        Ok(run_result) => match run_result {
+            Ok(_) => {
+                // Many consecutive comments loaded Ok, test passes
+                return;
+            }
+            Err(err) => {
+                panic!("Error loading consecutive comments: {err}");
+            }
+        },
+        Err(err) => {
+            panic!("Panic in thread loading consecutive comments: {err:?}");
+        }
+    }
+}

--- a/tests/many_consecutive_comments.rs
+++ b/tests/many_consecutive_comments.rs
@@ -42,7 +42,6 @@ where
         create_comment_callback(&mut w, i);
     }
     writeln!(w, "{{\"a\": 1}}").unwrap();
-    w.flush().unwrap();
     w
 }
 


### PR DESCRIPTION
Fix stack overflow bug
  
Fix bug that caused stack overflow when parsing many consecutive line or
block comments.

The problem was that parse_whitespace() calls parse_comment() which
indirectly calls parse_whitepace() again. So each consecutive line or
block comment would add more frames to the stack. This makes it possible
for a malicious actor to easily craft a JSONC document that will cause
your program to exit with a segfault.
